### PR TITLE
Fixed regression in injecting fields

### DIFF
--- a/Harmony/Internal/Patching/HarmonyManipulator.cs
+++ b/Harmony/Internal/Patching/HarmonyManipulator.cs
@@ -527,7 +527,7 @@ namespace HarmonyLib.Internal.Patching
                     }
                     else
                     {
-                        fieldInfo = AccessTools.DeclaredField(original.DeclaringType, fieldName);
+                        fieldInfo = AccessTools.Field(original.DeclaringType, fieldName);
                         if (fieldInfo == null)
                             throw new ArgumentException(
                                 $"No such field defined in class {original.DeclaringType.FullName}", fieldName);

--- a/HarmonyTests/Patching/Arguments.cs
+++ b/HarmonyTests/Patching/Arguments.cs
@@ -132,5 +132,38 @@ namespace HarmonyLibTests
             Assert.AreEqual(10, result.a);
             Assert.AreEqual(20, result.b);
         }
+
+
+        [Test]
+        public void Test_InjectingBaseClassField()
+        {
+            var testInstance = new InjectFieldSubClass();
+            testInstance.Method("foo");
+            Assert.AreEqual("foo", testInstance.TestValue);
+
+            var originalClass = testInstance.GetType();
+            Assert.IsNotNull(originalClass);
+            var originalMethod = originalClass.GetMethod("Method");
+            Assert.IsNotNull(originalMethod);
+
+            var patchClass = typeof(InjectFieldSubClass_Patch);
+            var postfix = patchClass.GetMethod("Postfix");
+            Assert.IsNotNull(postfix);
+
+            var instance = new Harmony("test");
+            Assert.IsNotNull(instance);
+
+            instance.Patch(originalMethod, postfix: new HarmonyMethod(postfix));
+
+            var patcher = new PatchProcessor(instance, originalMethod);
+            Assert.IsNotNull(patcher);
+            _ = patcher.AddPostfix(postfix);
+            Assert.IsNotNull(patcher);
+
+            _ = patcher.Patch();
+
+            testInstance.Method("bar");
+            Assert.AreEqual("patched", testInstance.TestValue);
+        }
     }
 }

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -633,6 +633,37 @@ namespace HarmonyLibTests.Assets
         }
     }
 
+    public class InjectFieldBase
+    {
+        internal string testField;
+    }
+
+    public class InjectFieldSubClass : InjectFieldBase
+    {
+        public string TestValue => testField;
+
+        public void Method(string val)
+        {
+            try
+            {
+                testField = val;
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(InjectFieldSubClass), nameof(InjectFieldSubClass.Method))]
+    public class InjectFieldSubClass_Patch
+    {
+        public static void Postfix(ref string ___testField)
+        {
+            ___testField = "patched";
+        }
+    }
+
     // disabled - see test case
     /*
     public class ClassExceptionFilter


### PR DESCRIPTION
From the Harmony repository: https://github.com/pardeike/Harmony/commit/3b8603e608119155bf80cb9bb98601816c26d8e2

This fixes an issue where inherited members were unable to be injected into the patch methods.