### PR TITLE
Add global flag to disallow global UnpatchAll behavior

### DIFF
--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -22,10 +22,6 @@ namespace HarmonyLib
 		// ReSharper disable once InconsistentNaming
 		public static bool DEBUG;
 
-		/// <summary>Set to true to disallow executing UnpatchAll without specifying a harmonyId.</summary>
-		/// <remarks>If set to true and UnpatchAll is called without passing a harmonyId, then said method will throw a HarmonyException</remarks>
-		public static bool DISALLOW_GLOBAL_UNPATCHALL;
-
 		static Harmony()
 		{
 			StackTraceFixes.Install();
@@ -215,17 +211,17 @@ namespace HarmonyLib
 		}
 
 		/// <summary>Unpatches methods by patching them with zero patches. Fully unpatching is not supported. Be careful, unpatching is global</summary>
-		/// <param name="harmonyID">The Harmony ID to restrict unpatching to a specific Harmony instance. Whether this parameter is actually optional is determined by the <see cref="DISALLOW_GLOBAL_UNPATCHALL"/> global flag</param>
-		/// <exception cref="HarmonyException">Exception gets thrown when <see cref="DISALLOW_GLOBAL_UNPATCHALL"/>=true and no <paramref name="harmonyID" /> is passed into the method</exception>
+		/// <param name="harmonyID">The Harmony ID to restrict unpatching to a specific Harmony instance. Whether this parameter is actually optional is determined by the <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/> global flag</param>
+		/// <exception cref="HarmonyException">Exception gets thrown when <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/>=true and no <paramref name="harmonyID" /> is passed into the method</exception>
 		/// <remarks>This method could be static if it wasn't for the fact that unpatching creates a new replacement method that contains your harmony ID</remarks>
 		///
 		public void UnpatchAll(string harmonyID = null)
 		{
 			if (harmonyID == null)
 			{
-				if (DISALLOW_GLOBAL_UNPATCHALL)
+				if (HarmonyGlobalSettings.DisallowGlobalUnpatchAll)
 				{
-					throw new HarmonyException("UnpatchAll has been called with harmonyID=null AND DISALLOW_GLOBAL_UNPATCHALL=true. " +
+					throw new HarmonyException("UnpatchAll has been called with harmonyID=null AND DisallowGlobalUnpatchAll=true. " +
 					                           "If you want to only unpatch patches created by this instance (" + Id + "), use UnpatchSelf() instead.");
 				}
 

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -22,6 +22,10 @@ namespace HarmonyLib
 		// ReSharper disable once InconsistentNaming
 		public static bool DEBUG;
 
+		/// <summary>Set to true to disallow executing UnpatchAll without specifying a harmonyId.</summary>
+		/// <remarks>If set to true and UnpatchAll is called without passing a harmonyId, then said method will throw a HarmonyException</remarks>
+		public static bool DISALLOW_GLOBAL_UNPATCHALL;
+
 		static Harmony()
 		{
 			StackTraceFixes.Install();
@@ -211,14 +215,23 @@ namespace HarmonyLib
 		}
 
 		/// <summary>Unpatches methods by patching them with zero patches. Fully unpatching is not supported. Be careful, unpatching is global</summary>
-		/// <param name="harmonyID">The optional Harmony ID to restrict unpatching to a specific Harmony instance</param>
+		/// <param name="harmonyID">The Harmony ID to restrict unpatching to a specific Harmony instance. Whether this parameter is actually optional is determined by the <see cref="DISALLOW_GLOBAL_UNPATCHALL"/> global flag</param>
+		/// <exception cref="HarmonyException">Exception gets thrown when <see cref="DISALLOW_GLOBAL_UNPATCHALL"/>=true and no <paramref name="harmonyID" /> is passed into the method</exception>
 		/// <remarks>This method could be static if it wasn't for the fact that unpatching creates a new replacement method that contains your harmony ID</remarks>
 		///
 		public void UnpatchAll(string harmonyID = null)
 		{
 			if (harmonyID == null)
+			{
+				if (DISALLOW_GLOBAL_UNPATCHALL)
+				{
+					throw new HarmonyException("UnpatchAll has been called with harmonyID=null AND DISALLOW_GLOBAL_UNPATCHALL=true. " +
+					                           "If you want to only unpatch patches created by this instance (" + Id + "), use UnpatchSelf() instead.");
+				}
+
 				Logger.Log(Logger.LogChannel.Warn, () => "UnpatchAll has been called with harmonyID=null - This will remove ALL HARMONY PATCHES. " +
 				                                         "If you want to only unpatch patches created by this instance (" + Id + "), use UnpatchSelf() instead.");
+			}
 
 			bool IDCheck(Patch patchInfo)
 			{

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -212,8 +212,7 @@ namespace HarmonyLib
 
 		/// <summary>Unpatches methods by patching them with zero patches. Fully unpatching is not supported. Be careful, unpatching is global</summary>
 		/// <param name="harmonyID">The Harmony ID to restrict unpatching to a specific Harmony instance. Whether this parameter is actually optional is determined by the <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/> global flag</param>
-		/// <exception cref="HarmonyException">Exception gets thrown when <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/>=true and no <paramref name="harmonyID" /> is passed into the method</exception>
-		/// <remarks>This method could be static if it wasn't for the fact that unpatching creates a new replacement method that contains your harmony ID</remarks>
+		/// <remarks>This method could be static if it wasn't for the fact that unpatching creates a new replacement method that contains your harmony ID. When <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/> is set to true, the execution of this method will be skipped.</remarks>
 		///
 		public void UnpatchAll(string harmonyID = null)
 		{
@@ -221,8 +220,9 @@ namespace HarmonyLib
 			{
 				if (HarmonyGlobalSettings.DisallowGlobalUnpatchAll)
 				{
-					throw new HarmonyException("UnpatchAll has been called with harmonyID=null AND DisallowGlobalUnpatchAll=true. " +
-					                           "If you want to only unpatch patches created by this instance (" + Id + "), use UnpatchSelf() instead.");
+					Logger.Log(Logger.LogChannel.Warn, () => "UnpatchAll has been called with harmonyID=null AND DisallowGlobalUnpatchAll=true. " +
+					                                         "If you want to only unpatch patches created by this instance (" + Id + "), use UnpatchSelf() instead.");
+					return;
 				}
 
 				Logger.Log(Logger.LogChannel.Warn, () => "UnpatchAll has been called with harmonyID=null - This will remove ALL HARMONY PATCHES. " +

--- a/Harmony/Public/HarmonyGlobalSettings.cs
+++ b/Harmony/Public/HarmonyGlobalSettings.cs
@@ -5,7 +5,7 @@ namespace HarmonyLib
 	public static class HarmonyGlobalSettings
 	{
 		/// <summary>Set to true to disallow executing UnpatchAll without specifying a harmonyId.</summary>
-		/// <remarks>If set to true and UnpatchAll is called without passing a harmonyId, then said method will throw a HarmonyException</remarks>
+		/// <remarks>If set to true and UnpatchAll is called without passing a harmonyId, then execution of said method will be skipped.</remarks>
 		public static bool DisallowGlobalUnpatchAll { get; set; }
 	}
 }

--- a/Harmony/Public/HarmonyGlobalSettings.cs
+++ b/Harmony/Public/HarmonyGlobalSettings.cs
@@ -1,0 +1,11 @@
+namespace HarmonyLib
+{
+	/// <summary>Class that holds all Global Harmony settings</summary>
+	///
+	public static class HarmonyGlobalSettings
+	{
+		/// <summary>Set to true to disallow executing UnpatchAll without specifying a harmonyId.</summary>
+		/// <remarks>If set to true and UnpatchAll is called without passing a harmonyId, then said method will throw a HarmonyException</remarks>
+		public static bool DisallowGlobalUnpatchAll { get; set; }
+	}
+}


### PR DESCRIPTION
This PR, as the title implies, adds a global flag to disallow the global UnpatchAll behavior.

This is an opt-in flag to keep binary compatibility and not introduce unexpected behavior by default, this while still being able to disallow the default behavior by turning on the flag.

Reasoning for introducing this flag is that, in certain contexts, it is often undesirable to unpatch every single patch at once
For example, in the case of modloaders where mods can be enabled/disabled at runtime and where accidentally calling the `.UnpatchAll()` method without an id, could break a whole bunch of other mods.