### PR TITLE
Static UnpatchAll and UnpatchID

### DIFF
--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -255,12 +255,19 @@ namespace HarmonyLib
 		[Obsolete("Use UnpatchSelf() to unpatch the current instance. The functionality to unpatch other ids or everything has been moved the static methods UnpatchID() and UnpatchAll()", true)]
 		public void UnpatchAll(string harmonyID = null)
 		{
-			if (string.IsNullOrEmpty(harmonyID))
+			if (harmonyID == null)
 			{
 				UnpatchAll();
 			}
 			else
 			{
+				if (harmonyID.Length == 0)
+				{
+					Logger.Log(Logger.LogChannel.Warn, () => "UnpatchAll was called with harmonyID=\"\" which is an invalid id. " +
+					                                         "Skipping execution of UnpatchAll");
+					return;
+				}
+
 				UnpatchID(harmonyID);
 			}
 		}

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -232,38 +232,37 @@ namespace HarmonyLib
 		}
 
 		/// <summary>Unpatches methods by patching them with zero patches. Fully unpatching is not supported. Be careful, unpatching is global</summary>
-		/// <remarks>When <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/> is set to true, the execution of this method will be skipped.</remarks>
 		///
 		public static void UnpatchAll()
 		{
-			if (HarmonyGlobalSettings.DisallowGlobalUnpatchAll)
-			{
-				Logger.Log(Logger.LogChannel.Warn, () => "UnpatchAll has been called AND DisallowGlobalUnpatchAll=true. " +
-				                                         "Skipping execution of UnpatchAll");
-				return;
-			}
-
 			Logger.Log(Logger.LogChannel.Warn, () => "UnpatchAll has been called - This will remove ALL HARMONY PATCHES.");
 
 			PatchFunctions.UnpatchConditional(_ => true);
 		}
 
 		/// <summary>Unpatches methods by patching them with zero patches. Fully unpatching is not supported. Be careful, unpatching is global</summary>
-		/// <param name="harmonyID">The Harmony ID to restrict unpatching to a specific Harmony instance. Whether this parameter is actually optional is determined by the <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/> global flag</param>
-		/// <remarks>When <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/> is set to true, the execution of this method will be skipped when no <paramref name="harmonyID"/> is specified.</remarks>
+		/// <param name="harmonyID">The Harmony ID to restrict unpatching to a specific Harmony instance. Whether this parameter is actually optional is determined by the <see cref="HarmonyGlobalSettings.DisallowLegacyGlobalUnpatchAll"/> global flag</param>
+		/// <remarks>When <see cref="HarmonyGlobalSettings.DisallowLegacyGlobalUnpatchAll"/> is set to true, the execution of this method will be skipped when no <paramref name="harmonyID"/> is specified.</remarks>
 		///
-		[Obsolete("Use UnpatchSelf() to unpatch the current instance. The functionality to unpatch other ids or everything has been moved the static methods UnpatchID() and UnpatchAll()", true)]
+		[Obsolete("Use UnpatchSelf() to unpatch the current instance. The functionality to unpatch either other ids or EVERYTHING has been moved the static methods UnpatchID() and UnpatchAll() respectively", true)]
 		public void UnpatchAll(string harmonyID = null)
 		{
 			if (harmonyID == null)
 			{
+				if (HarmonyGlobalSettings.DisallowLegacyGlobalUnpatchAll)
+				{
+					Logger.Log(Logger.LogChannel.Warn, () => "Legacy UnpatchAll has been called AND DisallowLegacyGlobalUnpatchAll=true. " +
+					                                         "Skipping execution of UnpatchAll");
+					return;
+				}
+
 				UnpatchAll();
 			}
 			else
 			{
 				if (harmonyID.Length == 0)
 				{
-					Logger.Log(Logger.LogChannel.Warn, () => "UnpatchAll was called with harmonyID=\"\" which is an invalid id. " +
+					Logger.Log(Logger.LogChannel.Warn, () => "Legacy UnpatchAll was called with harmonyID=\"\" which is an invalid id. " +
 					                                         "Skipping execution of UnpatchAll");
 					return;
 				}

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -221,7 +221,7 @@ namespace HarmonyLib
 				return;
 			}
 
-			UnpatchInternal(patchInfo => patchInfo.owner == harmonyID);
+			PatchFunctions.UnpatchConditional(patchInfo => patchInfo.owner == harmonyID);
 		}
 
 		/// <summary>Unpatches all methods that were patched by this Harmony instance's ID. Unpatching is done by repatching methods without patches of this instance.</summary>
@@ -248,29 +248,7 @@ namespace HarmonyLib
 
 			Logger.Log(Logger.LogChannel.Warn, () => "UnpatchAll has been called - This will remove ALL HARMONY PATCHES.");
 
-			UnpatchInternal(_ => true);
-		}
-
-		private static void UnpatchInternal(Func<Patch, bool> executionCondition)
-		{
-			var originals = GetAllPatchedMethods().ToList(); // keep as is to avoid "Collection was modified"
-			foreach (var original in originals)
-			{
-				var hasBody = original.HasMethodBody();
-				var info = GetPatchInfo(original);
-				var patchProcessor = new PatchProcessor(null, original);
-
-				if (hasBody)
-				{
-					info.Postfixes.DoIf(executionCondition, patchInfo => patchProcessor.Unpatch(patchInfo.PatchMethod));
-					info.Prefixes.DoIf(executionCondition, patchInfo => patchProcessor.Unpatch(patchInfo.PatchMethod));
-				}
-
-				info.ILManipulators.DoIf(executionCondition, patchInfo => patchProcessor.Unpatch(patchInfo.PatchMethod));
-				info.Transpilers.DoIf(executionCondition, patchInfo => patchProcessor.Unpatch(patchInfo.PatchMethod));
-				if (hasBody)
-					info.Finalizers.DoIf(executionCondition, patchInfo => patchProcessor.Unpatch(patchInfo.PatchMethod));
-			}
+			PatchFunctions.UnpatchConditional(_ => true);
 		}
 
 		/// <summary>Unpatches methods by patching them with zero patches. Fully unpatching is not supported. Be careful, unpatching is global</summary>

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -255,7 +255,7 @@ namespace HarmonyLib
 		/// <param name="harmonyID">The Harmony ID to restrict unpatching to a specific Harmony instance. Whether this parameter is actually optional is determined by the <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/> global flag</param>
 		/// <remarks>When <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/> is set to true, the execution of this method will be skipped when no <paramref name="harmonyID"/> is specified.</remarks>
 		///
-		[Obsolete("Use UnpatchSelf() to unpatch the current instance", true)]
+		[Obsolete("Use UnpatchSelf() to unpatch the current instance. The functionality to unpatch other ids or everything has been moved the static methods UnpatchID() and UnpatchAll()", true)]
 		public void UnpatchAll(string harmonyID = null)
 		{
 			if (string.IsNullOrEmpty(harmonyID))

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -212,13 +212,13 @@ namespace HarmonyLib
 
 		/// <summary>Unpatches all methods that were patched by the specified <paramref name="harmonyID"/>. Unpatching is done by repatching methods without patches of this instance.</summary>
 		/// <param name="harmonyID">The Harmony ID to restrict unpatching to a specific Harmony instance.</param>
+		/// <exception cref="ArgumentNullException">Gets thrown when a null or empty HarmonyID gets passed in.</exception>
+		///
 		public static void UnpatchID(string harmonyID)
 		{
 			if (string.IsNullOrEmpty(harmonyID))
 			{
-				Logger.Log(Logger.LogChannel.Warn, () => "UnpatchID has been called with a null or empty harmonyID. " +
-				                                         "Skipping execution of UnpatchID.");
-				return;
+				throw new ArgumentNullException(nameof(harmonyID) , "UnpatchID was called with a null or empty harmonyID.");
 			}
 
 			PatchFunctions.UnpatchConditional(patchInfo => patchInfo.owner == harmonyID);

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -231,7 +231,7 @@ namespace HarmonyLib
 			UnpatchID(Id);
 		}
 
-		/// <summary>Unpatches methods by patching them with zero patches. Fully unpatching is not supported. Be careful, unpatching is global</summary>
+		/// <summary>Globally unpatches ALL methods by patching them with zero patches. Complete unpatching is not supported.</summary>
 		///
 		public static void UnpatchAll()
 		{

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -210,7 +210,7 @@ namespace HarmonyLib
 			return PatchFunctions.ReversePatch(standin, original, transpiler, null);
 		}
 
-		/// <summary>Unpatches all methods that were patched by this Harmony instance's ID. Unpatching is done by repatching methods without patches of this instance.</summary>
+		/// <summary>Unpatches all methods that were patched by the specified <paramref name="harmonyID"/>. Unpatching is done by repatching methods without patches of this instance.</summary>
 		/// <param name="harmonyID">The Harmony ID to restrict unpatching to a specific Harmony instance.</param>
 		public static void UnpatchID(string harmonyID)
 		{

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -292,6 +292,7 @@ namespace HarmonyLib
 		/// <param name="harmonyID">The Harmony ID to restrict unpatching to a specific Harmony instance. Whether this parameter is actually optional is determined by the <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/> global flag</param>
 		/// <remarks>When <see cref="HarmonyGlobalSettings.DisallowGlobalUnpatchAll"/> is set to true, the execution of this method will be skipped when no <paramref name="harmonyID"/> is specified.</remarks>
 		///
+		[Obsolete("Use UnpatchSelf() to unpatch the current instance", true)]
 		public void UnpatchAll(string harmonyID = null)
 		{
 			if (string.IsNullOrEmpty(harmonyID))

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -238,12 +238,9 @@ namespace HarmonyLib
 		{
 			if (HarmonyGlobalSettings.DisallowGlobalUnpatchAll)
 			{
-				if (HarmonyGlobalSettings.DisallowGlobalUnpatchAll)
-				{
-					Logger.Log(Logger.LogChannel.Warn, () => "UnpatchAll has been called AND DisallowGlobalUnpatchAll=true. " +
-					                                         "Skipping execution of UnpatchAll");
-					return;
-				}
+				Logger.Log(Logger.LogChannel.Warn, () => "UnpatchAll has been called AND DisallowGlobalUnpatchAll=true. " +
+				                                         "Skipping execution of UnpatchAll");
+				return;
 			}
 
 			Logger.Log(Logger.LogChannel.Warn, () => "UnpatchAll has been called - This will remove ALL HARMONY PATCHES.");

--- a/Harmony/Public/HarmonyGlobalSettings.cs
+++ b/Harmony/Public/HarmonyGlobalSettings.cs
@@ -4,8 +4,8 @@ namespace HarmonyLib
 	///
 	public static class HarmonyGlobalSettings
 	{
-		/// <summary>Set to true to disallow executing UnpatchAll without specifying a harmonyId.</summary>
-		/// <remarks>If set to true and UnpatchAll is called without passing a harmonyId, then execution of said method will be skipped.</remarks>
-		public static bool DisallowGlobalUnpatchAll { get; set; }
+		/// <summary>Set to true to disallow executing the legacy instance <see cref="Harmony.UnpatchAll(string)"/> method without specifying a harmonyId.</summary>
+		/// <remarks>If set to true and the legacy instance <see cref="Harmony.UnpatchAll(string)"/> method is called without passing a harmonyId, then execution of said method will be skipped.</remarks>
+		public static bool DisallowLegacyGlobalUnpatchAll { get; set; }
 	}
 }

--- a/HarmonyTests/Patching/FinalizerPatches.cs
+++ b/HarmonyTests/Patching/FinalizerPatches.cs
@@ -216,7 +216,7 @@ namespace HarmonyLibTests.Patching
 			Assert.NotNull(finalizer, nameof(finalizer));
 
 			var instance = new Harmony("finalizer-test");
-			Harmony.UnpatchID("finalizer-test");
+			instance.UnpatchSelf();
 			var patcher = instance.CreateProcessor(originalMethod);
 			Assert.NotNull(patcher, nameof(patcher));
 			_ = patcher.AddFinalizer(finalizer);

--- a/HarmonyTests/Patching/FinalizerPatches.cs
+++ b/HarmonyTests/Patching/FinalizerPatches.cs
@@ -216,7 +216,7 @@ namespace HarmonyLibTests.Patching
 			Assert.NotNull(finalizer, nameof(finalizer));
 
 			var instance = new Harmony("finalizer-test");
-			instance.UnpatchAll("finalizer-test");
+			Harmony.UnpatchID("finalizer-test");
 			var patcher = instance.CreateProcessor(originalMethod);
 			Assert.NotNull(patcher, nameof(patcher));
 			_ = patcher.AddFinalizer(finalizer);

--- a/HarmonyTests/Patching/StaticPatches.cs
+++ b/HarmonyTests/Patching/StaticPatches.cs
@@ -196,7 +196,7 @@ namespace HarmonyLibTests.Patching
 			var instanceB = new Harmony("test");
 			Assert.NotNull(instanceB);
 
-			instanceB.UnpatchAll("unpatch-all-test");
+			Harmony.UnpatchID("unpatch-all-test");
 		}
 
 		[Test]


### PR DESCRIPTION
As a continuation following the discussion in PR #40, this PR handles the introduction of 2 (arguably) new static methods `Harmony.UnpatchAll()` and `Harmony.UnpatchID(string harmonyID)`.
Other than that, it also marks the old non-static `.UnpatchAll(string harmonyID = null)` as Obsolete.

Not sure how I can verify whether this actually works as intended, but the unit tests seem to run just fine, aside from a seemingly unrelated unit test that was already failing before the changes (`TestTraverse_Types.Traverse_InnerStatic`)

I think this covers everything that was mentioned in the other PR, but if I missed anything, please let me know.