### PR TITLE
Repro: .NET 7 Preview 4 breaks HarmonyX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         dotnet-version: | 
           3.1.x
           6.0.x
-          7.0.100-preview.3.22179.4
+          7.0.100-preview.2.22153.17
     - name: Log dotnet info
       run: dotnet --info
     - name: Run test
@@ -29,7 +29,7 @@ jobs:
         dotnet-version: | 
           3.1.x
           6.0.x
-          7.0.100-preview.3.22179.4
+          7.0.100-preview.2.22153.17
     
     - name: Make repo pushable
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         dotnet-version: | 
           3.1.x
           6.0.x
-          7.0.100-preview.2.22153.17
+          7.0.100-preview.1.22110.4
     - name: Log dotnet info
       run: dotnet --info
     - name: Run test
@@ -29,7 +29,7 @@ jobs:
         dotnet-version: | 
           3.1.x
           6.0.x
-          7.0.100-preview.2.22153.17
+          7.0.100-preview.1.22110.4
     
     - name: Make repo pushable
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
         dotnet-version: | 
           3.1.x
           6.0.x
+          7.0.100-preview.4.22252.9
     - name: Log dotnet info
       run: dotnet --info
     - name: Run test
@@ -28,6 +29,7 @@ jobs:
         dotnet-version: | 
           3.1.x
           6.0.x
+          7.0.100-preview.4.22252.9
     
     - name: Make repo pushable
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         dotnet-version: | 
           3.1.x
           6.0.x
-          7.0.100-preview.4.22252.9
+          7.0.100-preview.3.22179.4
     - name: Log dotnet info
       run: dotnet --info
     - name: Run test
@@ -29,7 +29,7 @@ jobs:
         dotnet-version: | 
           3.1.x
           6.0.x
-          7.0.100-preview.4.22252.9
+          7.0.100-preview.3.22179.4
     
     - name: Make repo pushable
       env:

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net35;net45;netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>net35;net45;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>

--- a/build.cake
+++ b/build.cake
@@ -47,7 +47,7 @@ Task("Test")
     .IsDependentOn("Build")
     .Does(() =>
 {
-	var testTargets = new [] { "net35", "netcoreapp3.1", "net6.0" };
+	var testTargets = new [] { "net35", "netcoreapp3.1", "net6.0", "net7.0" };
 	foreach (var target in testTargets)
 	{
 	    Information($"Testing {target}");


### PR DESCRIPTION
This PR shows that building and running on .NET SDK 7.0.100-preview.4.22252.9 breaks HarmonyX.
I found .NET 7 Preview 1 to work. I will, in subsequent commits, downgrade to preview 3, 2 and 1 to identify where the breaking change occured.

EDIT:
For Preview 1 and 2, there's 2 failing tests. Preview 1 works for us, but we're probably not using a broken feature.
For Preview 3 on, there's 56 failing tests.

EDIT:
Find the Github Actions runs here:

[Preview 4](https://github.com/danielcweber/HarmonyX/actions/runs/2396444292)
[Preview 3](https://github.com/danielcweber/HarmonyX/actions/runs/2396468227)
[Preview 2](https://github.com/danielcweber/HarmonyX/actions/runs/2396503098)
[Preview 1](https://github.com/danielcweber/HarmonyX/actions/runs/2396528370)
