### PR TITLE
Bugfix attempt for mismatched jump labels by IlProcessor

### DIFF
--- a/Harmony/Internal/Patching/ILManipulator.cs
+++ b/Harmony/Internal/Patching/ILManipulator.cs
@@ -347,9 +347,7 @@ internal class ILManipulator
 
 			// We need to handle exception handler opcodes specially because ILProcessor emits them automatically
 			// Case 1: leave + start or end of exception block => ILProcessor generates leave automatically
-			if ((cur.opcode == SRE.OpCodes.Leave || cur.opcode == SRE.OpCodes.Leave_S) &&
-			    (cur.blocks.Count > 0 || next?.blocks.Count > 0))
-				goto mark_block;
+			// Note: ILProcessor seems to generate some labels with wrong offset, clean-up code afterwards!
 			// Case 2: endfilter/endfinally and end of exception marker => ILProcessor will generate the correct end
 			if ((cur.opcode == SRE.OpCodes.Endfilter || cur.opcode == SRE.OpCodes.Endfinally) && cur.blocks.Count > 0)
 				goto mark_block;
@@ -378,6 +376,22 @@ internal class ILManipulator
 
 			mark_block:
 			cur.blocks.ForEach(b => il.MarkBlockAfter(b));
+		}
+
+		// Remove duplicate `leave` Op-Codes to cleanup
+		// Should be safe if "double-jumps" are not a thing
+		for (int i = 0; i < body.Instructions.Count - 1; i++)
+		{
+			// Find two leave instructions in a row to clean up
+			if (body.Instructions[i].OpCode != OpCodes.Leave &&
+				 body.Instructions[i].OpCode != OpCodes.Leave_S) continue;
+			if (body.Instructions[i + 1].OpCode != OpCodes.Leave &&
+				 body.Instructions[i + 1].OpCode != OpCodes.Leave_S) continue;
+			// Not exactly sure why this happens, labels should agree here!?
+			// if (body.Instructions[i].Offset != body.Instructions[i + 1].Offset)
+			// 	Logger.Log(Logger.LogChannel.Warn, () =>
+			// 		"Found conescutive leave ops that don't agree");
+			body.Instructions.RemoveAt(i + 1);
 		}
 
 		// Special Harmony interop case: if no instructions exist, at least emit a quick return to attempt to get a valid method


### PR DESCRIPTION
This is a potential BugFix for #65, although I don't really know the implications.
Please check and give feedback and I can adjust it accordingly if needed.
I certainly only tested it with my specific use case!

Addresses GitHub Issue #65

- Keep original leave jump labels as given by original IL.
- Clean-up unnecessary double leave op-codes (from IlProcessor).


Hope it's okay to add the dll if others want to test if this fix also works for them: [0Harmony.dll.zip](https://github.com/BepInEx/HarmonyX/files/11782505/0Harmony.dll.zip)
Note: I've had to up the net version to 48 as I don't have 45 on this PC ...

