### PR TITLE
fix double execution of TargetMethods

### DIFF
--- a/Harmony/Public/PatchClassProcessor.cs
+++ b/Harmony/Public/PatchClassProcessor.cs
@@ -231,20 +231,28 @@ namespace HarmonyLib
 				return list;
 			}
 
-			static string FailOnResult(IEnumerable<MethodBase> res)
-			{
-				if (res is null) return "null";
-				if (res.Any(m => m is null)) return "some element was null";
-				return null;
-			}
-			var targetMethods = RunMethod<HarmonyTargetMethods, IEnumerable<MethodBase>>(null, null, FailOnResult);
-			if (targetMethods is object)
-				return targetMethods.ToList();
-
 			var result = new List<MethodBase>();
+
+			var targetMethods = RunMethod<HarmonyTargetMethods, IEnumerable<MethodBase>>(null, null);
+			if (targetMethods is object)
+			{
+				string error = null;
+				result = targetMethods.ToList();
+				if (result is null) error = "null";
+				else if (result.Any(m => m is null)) error = "some element was null";
+				if (error != null)
+				{
+					if (auxilaryMethods.TryGetValue(typeof(HarmonyTargetMethods), out var method))
+						throw new Exception($"Method {method.FullDescription()} returned an unexpected result: {error}");
+					else
+						throw new Exception($"Some method returned an unexpected result: {error}");
+				}
+				return result;
+			}
 			var targetMethod = RunMethod<HarmonyTargetMethod, MethodBase>(null, null, method => method is null ? "null" : null);
 			if (targetMethod is object)
 				result.Add(targetMethod);
+
 			return result;
 		}
 


### PR DESCRIPTION
fix #76.

This is a bugfix from https://github.com/pardeike/Harmony/commit/7ab508c95e336619d0b77eb0918d74ac10fbcc2c, which fixes a bug where Harmony calls TargetMethods() always twice.

Unit test:
```
using System;
using HarmonyLib;
using System.Reflection;
namespace Test {
    internal class Program {
        static void Main(string[] args) {
            var harmony=new Harmony("fine");
            harmony.PatchAll();
        }
    }
    [HarmonyPatch]
    class Test {
        static IEnumerable<MethodBase> TargetMethods() {
            Console.WriteLine("Hello World!");
            yield break;
        }
    }
}
```
this simple program currently generate 2 `hello world`s, add another `harmony.PatchAll();` would generate 4 `hello world`s in total. After this patch, only one is generate per `PatchAll`.

@js6pak It seems @ghorsington has been inactive for half year, do you know what happened? And, could you please merge this PR for both HarmonyX and BepInEx?