### PR TITLE
Fix for unintentional removal of some `leave` instructions

### DIFF
--- a/Harmony/Internal/Patching/ILManipulator.cs
+++ b/Harmony/Internal/Patching/ILManipulator.cs
@@ -340,17 +340,13 @@ internal class ILManipulator
 		var newInstructions = ApplyTranspilers(cil, original, vDef => il.GetLocal(vDef), il.DefineLabel);
 
 		// Step 2: Emit code
-		foreach (var (cur, next) in newInstructions.Pairwise())
+		foreach (var cur in newInstructions)
 		{
 			cur.labels.ForEach(l => il.MarkLabel(l));
 			cur.blocks.ForEach(b => il.MarkBlockBefore(b));
 
 			// We need to handle exception handler opcodes specially because ILProcessor emits them automatically
-			// Case 1: leave + start or end of exception block => ILProcessor generates leave automatically
-			if ((cur.opcode == SRE.OpCodes.Leave || cur.opcode == SRE.OpCodes.Leave_S) &&
-			    (cur.blocks.Count > 0 || next?.blocks.Count > 0))
-				goto mark_block;
-			// Case 2: endfilter/endfinally and end of exception marker => ILProcessor will generate the correct end
+			// Case: endfilter/endfinally and end of exception marker => ILProcessor will generate the correct end
 			if ((cur.opcode == SRE.OpCodes.Endfilter || cur.opcode == SRE.OpCodes.Endfinally) && cur.blocks.Count > 0)
 				goto mark_block;
 			// Other cases are either intentional leave or invalid IL => let them be processed and let JIT generate correct exception

--- a/Harmony/Tools/Extensions.cs
+++ b/Harmony/Tools/Extensions.cs
@@ -595,30 +595,6 @@ namespace HarmonyLib
 				dict.Add(transform(pair.Key), pair.Value);
 			return dict;
 		}
-
-		// Iterates the enumerable pairwise, i.e. by returning tuple (current, next)
-		internal static IEnumerable<(T, T)> Pairwise<T>(this IEnumerable<T> self)
-		{
-			var isFirst = true;
-			T prev = default;
-
-			foreach (var e in self)
-				if (isFirst)
-				{
-					prev = e;
-					isFirst = false;
-				}
-				else
-				{
-					yield return (prev, e);
-					prev = e;
-				}
-
-			if (isFirst)
-				yield break;
-
-			yield return (prev, default);
-		}
 	}
 
 	/// <summary>General extensions for collections</summary>


### PR DESCRIPTION
My vision of #65 fix. Yes, this will keep 2 `leave` instructions, but it's jump anyway, no harm done. Upstream harmony makes it this way.
And, if someone wants to, they can find a way to remove these duplicates without offset shifting later on