### PR TITLE
Add HarmonyOptional attribute

### DIFF
--- a/Harmony/Internal/PatchTools.cs
+++ b/Harmony/Internal/PatchTools.cs
@@ -65,13 +65,13 @@ namespace HarmonyLib
 
 					case MethodType.Getter:
 						if (attr.methodName is null)
-							return AccessTools.DeclaredIndexer(attr.declaringType, attr.argumentTypes).GetGetMethod(true);
-						return AccessTools.DeclaredProperty(attr.declaringType, attr.methodName).GetGetMethod(true);
+							return AccessTools.DeclaredIndexer(attr.declaringType, attr.argumentTypes)?.GetGetMethod(true);
+						return AccessTools.DeclaredProperty(attr.declaringType, attr.methodName)?.GetGetMethod(true);
 
 					case MethodType.Setter:
 						if (attr.methodName is null)
-							return AccessTools.DeclaredIndexer(attr.declaringType, attr.argumentTypes).GetSetMethod(true);
-						return AccessTools.DeclaredProperty(attr.declaringType, attr.methodName).GetSetMethod(true);
+							return AccessTools.DeclaredIndexer(attr.declaringType, attr.argumentTypes)?.GetSetMethod(true);
+						return AccessTools.DeclaredProperty(attr.declaringType, attr.methodName)?.GetSetMethod(true);
 
 					case MethodType.Constructor:
 						return AccessTools.DeclaredConstructor(attr.GetDeclaringType(), attr.argumentTypes);

--- a/Harmony/Public/Attributes.cs
+++ b/Harmony/Public/Attributes.cs
@@ -778,30 +778,17 @@ namespace HarmonyLib
 		}
 	}
 
-	/// <summary> Flags used for optionally patching members that might not exist.</summary>
-	///
-	[Flags]
-	public enum OptionalFlags
-	{
-		/// <summary>Default behavior (throw and abort patching if there are no matches).</summary>
-		/// 
-		None = 0,
-
-		/// <summary> Do not throw an exception and abort the patching process if no matches are found (a warning is logged instead).</summary>
-		/// 
-		AllowNoMatches = 1 << 1,
-	}
-
-	/// <summary>Attribute used for optionally patching members that might not exist.</summary>
+	/// <summary>Attribute used for optionally patching members that might not exist.
+	/// Harmony patches with this attribute will not throw an exception and abort the patching process if the target member is not found (a warning is logged instead).</summary>
 	///
 	[AttributeUsage(AttributeTargets.Method)]
 	public class HarmonyOptional : HarmonyAttribute
 	{
 		/// <summary>Default constructor</summary>
 		///
-		public HarmonyOptional(OptionalFlags flags = OptionalFlags.AllowNoMatches)
+		public HarmonyOptional()
 		{
-			info.optionalFlags = flags;
+			info.optional = true;
 		}
 	}
 }

--- a/Harmony/Public/Attributes.cs
+++ b/Harmony/Public/Attributes.cs
@@ -777,4 +777,31 @@ namespace HarmonyLib
 			NewName = name;
 		}
 	}
+
+	/// <summary> Flags used for optionally patching members that might not exist.</summary>
+	///
+	[Flags]
+	public enum OptionalFlags
+	{
+		/// <summary>Default behavior (throw and abort patching if there are no matches).</summary>
+		/// 
+		None = 0,
+
+		/// <summary> Do not throw an exception and abort the patching process if no matches are found (a warning is logged instead).</summary>
+		/// 
+		AllowNoMatches = 1 << 1,
+	}
+
+	/// <summary>Attribute used for optionally patching members that might not exist.</summary>
+	///
+	[AttributeUsage(AttributeTargets.Method)]
+	public class HarmonyOptional : HarmonyAttribute
+	{
+		/// <summary>Default constructor</summary>
+		///
+		public HarmonyOptional(OptionalFlags flags = OptionalFlags.AllowNoMatches)
+		{
+			info.optionalFlags = flags;
+		}
+	}
 }

--- a/Harmony/Public/HarmonyMethod.cs
+++ b/Harmony/Public/HarmonyMethod.cs
@@ -67,9 +67,9 @@ namespace HarmonyLib
 		///
 		public bool? wrapTryCatch;
 		
-		/// <summary>Flags used for optionally patching members that might not exist.</summary>
+		/// <summary>Whether to not throw/abort when trying to patch members that do not exist (skip instead).</summary>
 		///
-		public OptionalFlags? optionalFlags;
+		public bool? optional;
 
 		/// <summary>Default constructor</summary>
 		///

--- a/Harmony/Public/HarmonyMethod.cs
+++ b/Harmony/Public/HarmonyMethod.cs
@@ -66,6 +66,10 @@ namespace HarmonyLib
 		/// <summary>Whether to wrap the patch itself into a try/catch.</summary>
 		///
 		public bool? wrapTryCatch;
+		
+		/// <summary>Flags used for optionally patching members that might not exist.</summary>
+		///
+		public OptionalFlags? optionalFlags;
 
 		/// <summary>Default constructor</summary>
 		///

--- a/Harmony/Public/PatchClassProcessor.cs
+++ b/Harmony/Public/PatchClassProcessor.cs
@@ -132,7 +132,7 @@ namespace HarmonyLib
 
 					if (lastOriginal is null)
 					{
-						if (IsPatchOptional(patchMethod))
+						if (patchMethod.info.optional == true)
 						{
 							Logger.Log(Logger.LogChannel.Warn, () => $"Skipping optional reverse patch {patchMethod.info.method.FullDescription()} - target method not found");
 							continue;
@@ -185,7 +185,7 @@ namespace HarmonyLib
 				lastOriginal = patchMethod.info.GetOriginalMethod();
 				if (lastOriginal is null)
 				{
-					if (IsPatchOptional(patchMethod))
+					if (patchMethod.info.optional == true)
 					{
 						Logger.Log(Logger.LogChannel.Warn, () => $"Skipping optional patch {patchMethod.info.method.FullDescription()} - target method not found");
 						continue;
@@ -203,13 +203,6 @@ namespace HarmonyLib
 				ProcessPatchJob(job);
 			}
 			return jobs.GetReplacements();
-		}
-
-		static bool IsPatchOptional(AttributePatch patchMethod)
-		{
-			var optionalFlags = patchMethod.info.optionalFlags;
-			var isOptional = optionalFlags != null && optionalFlags.Value.Has(OptionalFlags.AllowNoMatches);
-			return isOptional;
 		}
 
 		void ProcessPatchJob(PatchJobs<MethodInfo>.Job job)

--- a/Harmony/Public/PatchClassProcessor.cs
+++ b/Harmony/Public/PatchClassProcessor.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Text;
 using HarmonyLib.Public.Patching;
 using HarmonyLib.Tools;
-using MonoMod.Utils;
 
 namespace HarmonyLib
 {

--- a/Harmony/Public/PatchClassProcessor.cs
+++ b/Harmony/Public/PatchClassProcessor.cs
@@ -128,6 +128,8 @@ namespace HarmonyLib
 					var annotatedOriginal = patchMethod.info.GetOriginalMethod();
 					if (annotatedOriginal is object)
 						lastOriginal = annotatedOriginal;
+					if (lastOriginal is null)
+						throw new ArgumentException($"Undefined target method for reverse patch method {patchMethod.info.method.FullDescription()}");
 					var reversePatcher = instance.CreateReversePatcher(lastOriginal, patchMethod.info);
 					lock (PatchProcessor.locker)
 						_ = reversePatcher.Patch();

--- a/HarmonyTests/Patching/Assets/Specials.cs
+++ b/HarmonyTests/Patching/Assets/Specials.cs
@@ -147,20 +147,26 @@ namespace HarmonyLibTests.Assets
 		[HarmonyPostfix, HarmonyOptional, HarmonyPatch(typeof(OptionalPatch), nameof(NotEnumerator), MethodType.Async)]
 		public static void Test5() => throw new InvalidOperationException();
 
-		[HarmonyPostfix]
+		[HarmonyPrefix]
 		[HarmonyOptional]
 		[HarmonyPatch(typeof(OptionalPatch), "missing_method1")]
-		[HarmonyPatch(typeof(OptionalPatch), nameof(NotEnumerator), MethodType.Normal)]
+		[HarmonyPatch(typeof(OptionalPatch), nameof(Thrower), MethodType.Normal)]
 		[HarmonyPatch(typeof(OptionalPatch), "missing_method2")]
-		public static void Test6() => throw new InvalidOperationException();
+		public static bool Test6() => false;
 
 		private void NotEnumerator() => throw new InvalidOperationException();
+		public static void Thrower() => throw new InvalidOperationException();
 	}
 
 	public static class OptionalPatchNone
 	{
-		[HarmonyPrefix, HarmonyPatch(typeof(OptionalPatch), "missing_method")]
-		public static void Prefix() => throw new InvalidOperationException();
+		[HarmonyPrefix]
+		[HarmonyPatch(typeof(OptionalPatch), "missing_method1")]
+		[HarmonyPatch(typeof(OptionalPatch), nameof(Thrower), MethodType.Normal)]
+		[HarmonyPatch(typeof(OptionalPatch), "missing_method2")]
+		public static bool Test6() => false;
+
+		public static void Thrower() => throw new InvalidOperationException();
 	}
 
 	public static class SafeWrapPatch

--- a/HarmonyTests/Patching/Assets/Specials.cs
+++ b/HarmonyTests/Patching/Assets/Specials.cs
@@ -162,7 +162,7 @@ namespace HarmonyLibTests.Assets
 	{
 		[HarmonyPrefix]
 		[HarmonyPatch(typeof(OptionalPatch), "missing_method1")]
-		[HarmonyPatch(typeof(OptionalPatch), nameof(Thrower), MethodType.Normal)]
+		[HarmonyPatch(typeof(OptionalPatchNone), nameof(Thrower), MethodType.Normal)]
 		[HarmonyPatch(typeof(OptionalPatch), "missing_method2")]
 		public static bool Test6() => false;
 

--- a/HarmonyTests/Patching/Assets/Specials.cs
+++ b/HarmonyTests/Patching/Assets/Specials.cs
@@ -147,18 +147,20 @@ namespace HarmonyLibTests.Assets
 		[HarmonyPostfix, HarmonyOptional, HarmonyPatch(typeof(OptionalPatch), nameof(NotEnumerator), MethodType.Async)]
 		public static void Test5() => throw new InvalidOperationException();
 
+		[HarmonyPostfix]
+		[HarmonyOptional]
+		[HarmonyPatch(typeof(OptionalPatch), "missing_method1")]
+		[HarmonyPatch(typeof(OptionalPatch), nameof(NotEnumerator), MethodType.Normal)]
+		[HarmonyPatch(typeof(OptionalPatch), "missing_method2")]
+		public static void Test6() => throw new InvalidOperationException();
+
 		private void NotEnumerator() => throw new InvalidOperationException();
 	}
 
 	public static class OptionalPatchNone
 	{
-		[HarmonyPrefix]
-		[HarmonyOptional(OptionalFlags.None)]
-		[HarmonyPatch(typeof(OptionalPatch), "missing_method")]
-		public static void Prefix()
-		{
-			throw new InvalidOperationException();
-		}
+		[HarmonyPrefix, HarmonyPatch(typeof(OptionalPatch), "missing_method")]
+		public static void Prefix() => throw new InvalidOperationException();
 	}
 
 	public static class SafeWrapPatch

--- a/HarmonyTests/Patching/Assets/Specials.cs
+++ b/HarmonyTests/Patching/Assets/Specials.cs
@@ -127,6 +127,40 @@ namespace HarmonyLibTests.Assets
 		}
 	}
 
+	public class OptionalPatch
+	{
+		[HarmonyPrefix, HarmonyOptional, HarmonyPatch(typeof(OptionalPatch), "missing_method")]
+		public static void Test0() => throw new InvalidOperationException();
+
+		[HarmonyReversePatch, HarmonyOptional, HarmonyPatch(typeof(OptionalPatch), "missing_method")]
+		public static void Test1() => throw new InvalidOperationException();
+		
+		[HarmonyPostfix, HarmonyOptional, HarmonyPatch(typeof(OptionalPatch), MethodType.Constructor, typeof(string))]
+		public static void Test2() => throw new InvalidOperationException();
+		
+		[HarmonyTranspiler, HarmonyOptional, HarmonyPatch(typeof(OptionalPatch), "missing_method", MethodType.Getter)]
+		public static void Test3() => throw new InvalidOperationException();
+
+		[HarmonyPostfix, HarmonyOptional, HarmonyPatch(typeof(OptionalPatch), nameof(NotEnumerator), MethodType.Enumerator)]
+		public static void Test4() => throw new InvalidOperationException();
+
+		[HarmonyPostfix, HarmonyOptional, HarmonyPatch(typeof(OptionalPatch), nameof(NotEnumerator), MethodType.Async)]
+		public static void Test5() => throw new InvalidOperationException();
+
+		private void NotEnumerator() => throw new InvalidOperationException();
+	}
+
+	public static class OptionalPatchNone
+	{
+		[HarmonyPrefix]
+		[HarmonyOptional(OptionalFlags.None)]
+		[HarmonyPatch(typeof(OptionalPatch), "missing_method")]
+		public static void Prefix()
+		{
+			throw new InvalidOperationException();
+		}
+	}
+
 	public static class SafeWrapPatch
 	{
 		public static bool called = false;

--- a/HarmonyTests/Patching/Specials.cs
+++ b/HarmonyTests/Patching/Specials.cs
@@ -48,9 +48,13 @@ namespace HarmonyLibTests.Patching
 			var instance = new Harmony("special-case-optional-patch");
 			Assert.NotNull(instance);
 
+			Assert.Throws<InvalidOperationException>(OptionalPatch.Thrower);
 			Assert.DoesNotThrow(() => instance.PatchAll(typeof(OptionalPatch)));
+			Assert.DoesNotThrow(OptionalPatch.Thrower);
 
+			Assert.Throws<InvalidOperationException>(OptionalPatchNone.Thrower);
 			Assert.Throws<HarmonyException>(() => instance.PatchAll(typeof(OptionalPatchNone)));
+			Assert.Throws<InvalidOperationException>(OptionalPatchNone.Thrower);
 		}
 
 		[Test]

--- a/HarmonyTests/Patching/Specials.cs
+++ b/HarmonyTests/Patching/Specials.cs
@@ -43,6 +43,17 @@ namespace HarmonyLibTests.Patching
 		*/
 
 		[Test]
+		public void Test_Optional_Patch()
+		{
+			var instance = new Harmony("special-case-optional-patch");
+			Assert.NotNull(instance);
+
+			Assert.DoesNotThrow(() => instance.PatchAll(typeof(OptionalPatch)));
+
+			Assert.Throws<HarmonyException>(() => instance.PatchAll(typeof(OptionalPatchNone)));
+		}
+
+		[Test]
 		public void Test_Wrap_Patch()
 		{
 			SafeWrapPatch.called = false;
@@ -185,7 +196,7 @@ namespace HarmonyLibTests.Patching
 			Assert.AreEqual("MoveNext", EnumeratorPatch.patchTarget.Name);
 
 			var testObject = new EnumeratorCode();
-			Assert.AreEqual(new []{ 1, 2, 3, 4, 5 }, testObject.NumberEnumerator().ToArray());
+			Assert.AreEqual(new[] { 1, 2, 3, 4, 5 }, testObject.NumberEnumerator().ToArray());
 			Assert.AreEqual(6, EnumeratorPatch.runTimes);
 		}
 


### PR DESCRIPTION
Add a patch attribute that marks the patch as optional - if the method is not found or patching fails, the patch process is not aborted and there's a warning given, not an error.

For now only missing methods are handled, not exceptions.

Resolves #47 