### PR TITLE
Upgrade MonoMod.RuntimeDetour to 25.1.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<HarmonyXVersion>2.12.0</HarmonyXVersion>
 		<HarmonyXVersionFull>2.12.0.0</HarmonyXVersionFull>
 		<HarmonyXVersionSuffix></HarmonyXVersionSuffix>
-		<MonoModRuntimeDetour>25.1.1</MonoModRuntimeDetour>
+		<MonoModRuntimeDetour>25.1.2</MonoModRuntimeDetour>
 	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This upgrades the version of monomod to be the latest which includes important fixes for old mono (shipped with unity 2019.1 and earlier, but stopped being the default since 2018.1).

I have tested that locally upgrading BepinEx and BepinEx.Harmony to the version of harmony generated after this pr to work perfectly on new or old mono.

Since this is harmonyx itself, this isn't a breaking change: it just allows old mono to work now. A new harmonyx release needs to happen with this pr for me to send PRs to BepinEx and BepinEx.Harmony so more tests can be conducted and discussed there.