### PR TITLE
Update MonoMod to 25.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<HarmonyXVersion>2.14.0</HarmonyXVersion>
 		<HarmonyXVersionFull>2.14.0.0</HarmonyXVersionFull>
 		<HarmonyXVersionSuffix></HarmonyXVersionSuffix>
-		<MonoModRuntimeDetour>25.2.2</MonoModRuntimeDetour>
+		<MonoModRuntimeDetour>25.3.0</MonoModRuntimeDetour>
 	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This is what 2.4.0 vanilla uses, but a full rebase is very complex for me to do.

This MonoMod version is the first to feature ARM support (including Apple Silicon). This PR just upgrades it since there doesn't seem to be breaking changes so ARM support can be tested independently.