### PR TITLE
Bump MonoMod.RuntimeDetour version to 25.3.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<HarmonyXVersion>2.16.0</HarmonyXVersion>
 		<HarmonyXVersionFull>2.16.0.0</HarmonyXVersionFull>
 		<HarmonyXVersionSuffix></HarmonyXVersionSuffix>
-		<MonoModRuntimeDetour>25.3.3</MonoModRuntimeDetour>
+		<MonoModRuntimeDetour>25.3.4</MonoModRuntimeDetour>
 	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
I checked the commits since and I didn't see any breaking changes.