### PR TITLE
Bump MonoMod.RuntimeDetour version to 25.3.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<HarmonyXVersion>2.16.1</HarmonyXVersion>
 		<HarmonyXVersionFull>2.16.1.0</HarmonyXVersionFull>
 		<HarmonyXVersionSuffix></HarmonyXVersionSuffix>
-		<MonoModRuntimeDetour>25.3.4</MonoModRuntimeDetour>
+		<MonoModRuntimeDetour>25.3.5</MonoModRuntimeDetour>
 	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This contains an important fix for Linux users. I would appreciate it if you could make a release as soon as possible.
See https://github.com/MonoMod/MonoMod/pull/308 for details.